### PR TITLE
Include license files and readme into the source distribution

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@
 - Chris Beaven
 - Paul McLanahan
 - Michal Čihař
+- Bruno Oliveira

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include LICENSE-allkeys
+include README.md
+


### PR DESCRIPTION
Thanks for your work on this package!

Adds the license files and readme to the source distribution.

Some package systems that build from source distributions recommend including the license file into the built binaries, which cannot be done if the source distribution does not include it.

Specifically, I'm creating a recipe for `pyuca` for `conda-forge`: xref: conda-forge/staged-recipes#3875

Let me know if you would like maintainer access to that recipe! 👍 